### PR TITLE
Convert to RGB mode only on jpeg save

### DIFF
--- a/photologue/models.py
+++ b/photologue/models.py
@@ -427,12 +427,12 @@ class ImageModel(models.Model):
         im_filename = getattr(self, "get_%s_filename" % photosize.name)()
         try:
             buffer = BytesIO()
-            # Issue #182 - test fix from https://github.com/bashu/django-watermark/issues/31
-            if im.mode.endswith('A'):
-                im = im.convert(im.mode[:-1])
             if im_format != 'JPEG':
                 im.save(buffer, im_format)
             else:
+                # Issue #182 - test fix from https://github.com/bashu/django-watermark/issues/31
+                if im.mode.endswith('A'):
+                    im = im.convert(im.mode[:-1])
                 im.save(buffer, 'JPEG', quality=int(photosize.quality),
                         optimize=True)
             buffer_contents = ContentFile(buffer.getvalue())


### PR DESCRIPTION
Creating PNG image sizes with transparency (RGBA image mode) will fail since alpha channel will be removed from image.
Convert image to RGB mode only if image format is JPEG