### PR TITLE
Apply crop/effect changes to existing images

### DIFF
--- a/photologue/tests/factories.py
+++ b/photologue/tests/factories.py
@@ -12,7 +12,7 @@ except ImportError:
     raise ImportError(
         "No module named factory. To run photologue's tests you need to install factory-boy.")
 
-from ..models import Gallery, ImageModel, Photo, PhotoSize
+from ..models import Gallery, ImageModel, Photo, PhotoEffect, PhotoSize
 
 RES_DIR = os.path.join(os.path.dirname(__file__), '../res')
 LANDSCAPE_IMAGE_PATH = os.path.join(RES_DIR, 'test_photologue_landscape.jpg')
@@ -112,3 +112,11 @@ class PhotoSizeFactory(factory.django.DjangoModelFactory):
         model = PhotoSize
 
     name = factory.Sequence(lambda n: 'name{0:0>3}'.format(n))
+
+
+class PhotoEffectFactory(factory.django.DjangoModelFactory):
+
+    class Meta:
+        model = PhotoEffect
+
+    name = factory.Sequence(lambda n: 'effect{0:0>3}'.format(n))

--- a/photologue/tests/test_photo.py
+++ b/photologue/tests/test_photo.py
@@ -7,9 +7,10 @@ from django.conf import settings
 from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
 from io import BytesIO
+from unittest.mock import patch
 
 from .factories import LANDSCAPE_IMAGE_PATH, QUOTING_IMAGE_PATH, \
-    UNICODE_IMAGE_PATH, NONSENSE_IMAGE_PATH, GalleryFactory, PhotoFactory
+    UNICODE_IMAGE_PATH, NONSENSE_IMAGE_PATH, GalleryFactory, PhotoEffectFactory, PhotoFactory
 from .helpers import PhotologueBaseTest
 from ..models import Image, Photo, PHOTOLOGUE_DIR, PHOTOLOGUE_CACHEDIRTAG
 
@@ -103,6 +104,26 @@ class PhotoTest(PhotologueBaseTest):
         (I was trying to track down an elusive unicode issue elsewhere)"""
         self.pl2 = PhotoFactory(title='É',
                                 slug='é')
+
+    @patch('photologue.models.ImageModel.resize_image')
+    def test_update_cropping_applied(self, mock_resize_image):
+        self.assertEqual(1, Photo.objects.count())
+        self.assertTrue(self.pl.crop_from != 'right')
+        self.pl.crop_from = 'right'
+        self.pl.save()
+        self.assertTrue(mock_resize_image.called)
+
+    @patch('photologue.models.ImageModel.resize_image')
+    @patch('photologue.models.PhotoEffect.pre_process')
+    @patch('photologue.models.PhotoEffect.post_process')
+    def test_update_effect_applied(self, mock_post_process, mock_pre_process, mock_resize_image):
+        self.assertEqual(1, Photo.objects.count())
+        self.assertIsNone(self.pl.effect)
+        self.pl.effect = PhotoEffectFactory()
+        self.pl.save()
+        self.assertTrue(mock_pre_process.called)
+        self.assertTrue(mock_resize_image.called)
+        self.assertTrue(mock_post_process.called)
 
 
 class PhotoManagerTest(PhotologueBaseTest):

--- a/photologue/tests/test_photo.py
+++ b/photologue/tests/test_photo.py
@@ -106,7 +106,7 @@ class PhotoTest(PhotologueBaseTest):
                                 slug='é')
 
     @patch('photologue.models.ImageModel.resize_image')
-    def test_update_cropping_applied(self, mock_resize_image):
+    def test_update_crop_applied(self, mock_resize_image):
         self.assertEqual(1, Photo.objects.count())
         self.assertTrue(self.pl.crop_from != 'right')
         self.pl.crop_from = 'right'


### PR DESCRIPTION
Changing `crop_from` or `effect` property on existing `Photo` objects does not save/apply changes on image files.
Additional kwargs variable (`recreate`) is added to `Photo.save` method to handle image recreation flow in case of `crop_from` or `effect` changes on Photo objects.
