### PR TITLE
Add programmatic functionality for uploading zip file

### DIFF
--- a/photologue/forms.py
+++ b/photologue/forms.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import zipfile
-from dataclasses import dataclass
 from io import BytesIO
 from typing import List
 from zipfile import BadZipFile
@@ -24,17 +23,24 @@ logger = logging.getLogger('photologue.forms')
 MessageSeverity = int
 MessageContent = str
 
-@dataclass
 class PhotoDefaults:
     title: str
     caption: str
     is_public: bool
 
+    def __init__(self, title: str, caption: str, is_public: bool) -> "PhotoDefaults":
+        self.title = title
+        self.caption = caption
+        self.is_public = is_public
 
-@dataclass
+
 class UploadMessage:
     severity: MessageSeverity
     content: MessageContent
+
+    def __init__(self, severity: MessageSeverity, content: MessageContent) -> "UploadMessage":
+        self.severity = severity
+        self.content = content
 
     def success(content: MessageContent):
         return UploadMessage(severity=constants.SUCCESS, content=content)

--- a/photologue/forms.py
+++ b/photologue/forms.py
@@ -1,12 +1,15 @@
 import logging
 import os
 import zipfile
+from dataclasses import dataclass
 from io import BytesIO
+from typing import List
 from zipfile import BadZipFile
 
 from django import forms
 from django.conf import settings
 from django.contrib import messages
+from django.contrib.messages import constants
 from django.contrib.sites.models import Site
 from django.core.files.base import ContentFile
 from django.template.defaultfilters import slugify
@@ -17,6 +20,27 @@ from PIL import Image
 from .models import Gallery, Photo
 
 logger = logging.getLogger('photologue.forms')
+
+MessageSeverity = int
+MessageContent = str
+
+@dataclass
+class PhotoDefaults:
+    title: str
+    caption: str
+    is_public: bool
+
+
+@dataclass
+class UploadMessage:
+    severity: MessageSeverity
+    content: MessageContent
+
+    def success(content: MessageContent):
+        return UploadMessage(severity=constants.SUCCESS, content=content)
+
+    def warning(content: MessageContent):
+        return UploadMessage(severity=constants.WARNING, content=content)
 
 
 class UploadZipForm(forms.Form):
@@ -83,90 +107,107 @@ class UploadZipForm(forms.Form):
     def save(self, request=None, zip_file=None):
         if not zip_file:
             zip_file = self.cleaned_data['zip_file']
+
         zip = zipfile.ZipFile(zip_file)
-        count = 1
+        photo_defaults = PhotoDefaults(title=self.cleaned_data["title"], caption=self.cleaned_data["caption"], is_public=self.cleaned_data["is_public"])
         current_site = Site.objects.get(id=settings.SITE_ID)
+
+        gallery = self._reuse_or_create_gallery_in_site(current_site)
+
+        upload_messages = upload_photos_to_site(current_site, zip, gallery, photo_defaults)
+
+        if request:
+            for upload_message in upload_messages:
+                messages.add_message(request, upload_message.severity, upload_message.content, fail_silently=True)
+
+    def _reuse_or_create_gallery_in_site(self, current_site):
         if self.cleaned_data['gallery']:
             logger.debug('Using pre-existing gallery.')
             gallery = self.cleaned_data['gallery']
         else:
             logger.debug(
                 force_str('Creating new gallery "{0}".').format(self.cleaned_data['title']))
-            gallery = Gallery.objects.create(title=self.cleaned_data['title'],
-                                             slug=slugify(self.cleaned_data['title']),
-                                             description=self.cleaned_data['description'],
-                                             is_public=self.cleaned_data['is_public'])
-            gallery.sites.add(current_site)
-        for filename in sorted(zip.namelist()):
+            gallery = create_gallery_in_site(current_site,
+                                            title=self.cleaned_data['title'],
+                                            description=self.cleaned_data['description'],
+                                            is_public=self.cleaned_data['is_public'])
 
-            logger.debug('Reading file "{}".'.format(filename))
+        return gallery
 
-            if filename.startswith('__') or filename.startswith('.'):
-                logger.debug('Ignoring file "{}".'.format(filename))
+
+def create_gallery_in_site(site: Site, title: str, description: str = "", is_public: bool = False) -> Gallery:
+    gallery = Gallery.objects.create(title=title,
+                                        slug=slugify(title),
+                                        description=description,
+                                        is_public=is_public)
+    gallery.sites.add(site)
+    return gallery
+
+
+def upload_photos_to_site(site: Site, zip: zipfile.ZipFile, gallery: Gallery, photo_defaults: PhotoDefaults) -> List[UploadMessage]:
+    upload_messages = []
+    count = 1
+
+    for filename in sorted(zip.namelist()):
+
+        logger.debug('Reading file "{}".'.format(filename))
+
+        if filename.startswith('__') or filename.startswith('.'):
+            logger.debug('Ignoring file "{}".'.format(filename))
+            continue
+
+        if os.path.dirname(filename):
+            logger.warning('Ignoring file "{}" as it is in a subfolder; all images should be in the top '
+                            'folder of the zip.'.format(filename))
+            upload_messages.append(UploadMessage.warning(_('Ignoring file "{filename}" as it is in a subfolder; all images should be in the top folder of the zip.').format(filename=filename)))
+            continue
+
+        data = zip.read(filename)
+
+        if not len(data):
+            logger.debug('File "{}" is empty.'.format(filename))
+            continue
+
+        photo_title_root = photo_defaults.title if photo_defaults.title else gallery.title
+
+        # A photo might already exist with the same slug. So it's somewhat inefficient,
+        # but we loop until we find a slug that's available.
+        while True:
+            photo_title = ' '.join([photo_title_root, str(count)])
+            slug = slugify(photo_title)
+            if Photo.objects.filter(slug=slug).exists():
+                count += 1
                 continue
+            break
 
-            if os.path.dirname(filename):
-                logger.warning('Ignoring file "{}" as it is in a subfolder; all images should be in the top '
-                               'folder of the zip.'.format(filename))
-                if request:
-                    messages.warning(request,
-                                     _('Ignoring file "{filename}" as it is in a subfolder; all images should '
-                                       'be in the top folder of the zip.').format(filename=filename),
-                                     fail_silently=True)
-                continue
+        photo = Photo(title=photo_title,
+                        slug=slug,
+                        caption=photo_defaults.caption,
+                        is_public=photo_defaults.is_public)
 
-            data = zip.read(filename)
+        # Basic check that we have a valid image.
+        try:
+            file = BytesIO(data)
+            opened = Image.open(file)
+            opened.verify()
+        except Exception:
+            # Pillow doesn't recognize it as an image.
+            # If a "bad" file is found we just skip it.
+            # But we do flag this both in the logs and to the user.
+            logger.error('Could not process file "{}" in the .zip archive.'.format(
+                filename))
+            upload_messages.append(UploadMessage.warning(_('Could not process file "{0}" in the .zip archive.').format(filename)))
+            continue
 
-            if not len(data):
-                logger.debug('File "{}" is empty.'.format(filename))
-                continue
+        contentfile = ContentFile(data)
+        photo.image.save(filename, contentfile)
+        photo.save()
+        photo.sites.add(site)
+        gallery.photos.add(photo)
+        count += 1
 
-            photo_title_root = self.cleaned_data['title'] if self.cleaned_data['title'] else gallery.title
+    zip.close()
 
-            # A photo might already exist with the same slug. So it's somewhat inefficient,
-            # but we loop until we find a slug that's available.
-            while True:
-                photo_title = ' '.join([photo_title_root, str(count)])
-                slug = slugify(photo_title)
-                if Photo.objects.filter(slug=slug).exists():
-                    count += 1
-                    continue
-                break
+    upload_messages.append(UploadMessage.success(_('The photos have been added to gallery "{0}".').format(gallery.title)))
 
-            photo = Photo(title=photo_title,
-                          slug=slug,
-                          caption=self.cleaned_data['caption'],
-                          is_public=self.cleaned_data['is_public'])
-
-            # Basic check that we have a valid image.
-            try:
-                file = BytesIO(data)
-                opened = Image.open(file)
-                opened.verify()
-            except Exception:
-                # Pillow doesn't recognize it as an image.
-                # If a "bad" file is found we just skip it.
-                # But we do flag this both in the logs and to the user.
-                logger.error('Could not process file "{}" in the .zip archive.'.format(
-                    filename))
-                if request:
-                    messages.warning(request,
-                                     _('Could not process file "{0}" in the .zip archive.').format(
-                                         filename),
-                                     fail_silently=True)
-                continue
-
-            contentfile = ContentFile(data)
-            photo.image.save(filename, contentfile)
-            photo.save()
-            photo.sites.add(current_site)
-            gallery.photos.add(photo)
-            count += 1
-
-        zip.close()
-
-        if request:
-            messages.success(request,
-                             _('The photos have been added to gallery "{0}".').format(
-                                 gallery.title),
-                             fail_silently=True)
+    return upload_messages


### PR DESCRIPTION
Hey maintainers,

first of all: Thanks your effort! You're keeping this project useful and alive!

I wanted to have a programmatic way of uploading zip files to the database. Something I could use inside the Django shell. At the moment, I'm utilizing `UploadZipForm` but it feels kind of clunky and it doesn't support setting a specific publishing date on the `Gallery`.

This PR refactors `UploadZipForm.save` into a new function:
```python
def upload_photos_to_site(
    site: Site,
    zip: ZipFile,
    gallery: Gallery,
    photo_defaults: PhotoDefaults
) -> List[UploadMessage]:
    ...
```

## TODO
- Code formatting (Is there an automatic tool for this? Maybe black?)